### PR TITLE
Update the code limiting the vignette thumbnailer backends to use

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -27,7 +27,7 @@ Required library packages:
 
 Optional library packages:
 
-+ `vignette`_
++ `vignette`_ >= 4.3.0
 
   Needed to cache thumbnail images for the overview window.  If
   vignette is not available, everything will still work, but

--- a/photo/qt/image.py
+++ b/photo/qt/image.py
@@ -8,15 +8,22 @@ try:
 except ImportError:
     vignette = None
 
-# Disable vignette tumbnailer backends that are not useful in the
-# context of photo-tools.
+# Limit the vignette thumbnailer backends to those dealing with images.
 if vignette:
-    for backcls in (vignette.OooCliBackend, 
-                    vignette.PopplerCliBackend, 
-                    vignette.FFMpegCliBackend):
-        for i in reversed(range(len(vignette.THUMBNAILER_BACKENDS))):
-            if isinstance(vignette.THUMBNAILER_BACKENDS[i], backcls):
-                del vignette.THUMBNAILER_BACKENDS[i]
+    try:
+        # vignette 4.5.2 or newer
+        vignette.select_thumbnailer_types([vignette.FILETYPE_IMAGE])
+    except AttributeError:
+        if hasattr(vignette, 'THUMBNAILER_BACKENDS'):
+            # vignette 4.3.0 or newer
+            vignette.THUMBNAILER_BACKENDS = [
+                vignette.QtBackend(),
+                vignette.PilBackend(),
+                vignette.MagickBackend()
+            ]
+        else:
+            # vignette is too old to be usable
+            vignette = None
 
 
 class ImageNotFoundError(Exception):


### PR DESCRIPTION
`vignette` 4.5.2 adds a module function `select_thumbnailer_types()` allowing to select the types of thumbnailer backend to use, see hydrargyrum/vignette#4. This may be used to replace the kludge that is currently used in `photo.qt.image` for this purpose (and that was not working with `vignette` 4.4.0 btw).