### PR TITLE
Python: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated

### DIFF
--- a/photo/geo.py
+++ b/photo/geo.py
@@ -3,7 +3,7 @@
 
 import re
 import math
-from collections import Mapping
+from collections.abc import Mapping
 
 
 _geopos_pattern = (r"^\s*(?P<lat>\d+(?:\.\d*))\s*(?P<latref>N|S),\s*"

--- a/photo/idxfilter.py
+++ b/photo/idxfilter.py
@@ -2,7 +2,6 @@
 """
 
 import argparse
-import collections
 import datetime
 from pathlib import Path
 import re

--- a/photo/index.py
+++ b/photo/index.py
@@ -1,7 +1,7 @@
 """Provide the class Index which represents an index of photos.
 """
 
-from collections import MutableSequence
+from collections.abc import MutableSequence
 import errno
 import fcntl
 import os

--- a/photo/listtools.py
+++ b/photo/listtools.py
@@ -8,7 +8,7 @@ future versions of the photo-tools distribution without further
 notice.
 """
 
-from collections import MutableSequence
+from collections.abc import MutableSequence
 
 class LazyList(MutableSequence):
     """A list generated lazily from an iterable.


### PR DESCRIPTION
Python 3.7 emits the following warning: `DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working`.  This concerns:

- `from collections import Mapping` in `photo/geo.py`
- `from collections import MutableSequence` in `photo/index.py`
- `from collections import MutableSequence` in `photo/listtools.py`

Change the import to `from collections.abc import …`.  Furthermore, remove a spurious `import collections` in `photo/idxfilter.py`.