### PR TITLE
Use setuptools_scm to manage the version number

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
-*.pyc
 *~
 __pycache__/
 /.cache/
 /.env
+/.version
 /MANIFEST
 /build/
 /dist/
+/photo/__init__.py

--- a/.req
+++ b/.req
@@ -4,3 +4,4 @@ distutils-pytest
 exif >= 0.8.3
 pytest >= 3.6.0
 pytest-dependency
+setuptools_scm

--- a/CHANGES
+++ b/CHANGES
@@ -12,6 +12,8 @@
  + PR #49: Fix DeprecationWarning about importing the ABCs from
    'collections'.
 
+ + Issue #47, PR #50: Use setuptools_scm to manage the version number.
+
 * Version 0.9.3 (2020-05-03)
 
 ** Bug fixes and minor changes

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include .version
 include CHANGES
 include LICENSE.txt
 include MANIFEST.in

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 PYTHON   = python3
+BUILDLIB = $(CURDIR)/build/lib
 
 
 build:
@@ -15,11 +16,14 @@ clean:
 	rm -rf build
 
 distclean: clean
-	rm -f MANIFEST
-	rm -f photo/*.pyc photo/qt/*.pyc tests/*.pyc
+	rm -f MANIFEST .version
+	rm -f photo-tools/__init__.py
 	rm -rf .cache
 	rm -rf photo/__pycache__ photo/qt/__pycache__ tests/__pycache__
 	rm -rf dist
 
+init_py:
+	$(PYTHON) setup.py init_py
 
-.PHONY: build test sdist clean distclean
+
+.PHONY: build test sdist clean distclean init_py

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,14 @@ Optional library packages:
   vignette is not available, everything will still work, but
   displaying the overview window may be significantly slower.
 
++ `setuptools_scm`_
+
+  The version number is managed using this package.  All source
+  distributions add a static text file with the version number and
+  fall back using that if `setuptools_scm` is not available.  So this
+  package is only needed to build out of the plain development source
+  tree as cloned from GitHub.
+
 + `pytest`_
 
   Only needed to run the test suite.
@@ -93,6 +101,7 @@ permissions and limitations under the License.
 .. _exif: https://github.com/TNThieding/exif
 .. _PySide: https://wiki.qt.io/PySide
 .. _vignette: https://github.com/hydrargyrum/vignette
+.. _setuptools_scm: https://github.com/pypa/setuptools_scm/
 .. _pytest: https://pytest.org/
 .. _pytest-dependency: https://github.com/RKrahl/pytest-dependency
 .. _distutils-pytest: https://github.com/RKrahl/distutils-pytest

--- a/photo/__init__.py
+++ b/photo/__init__.py
@@ -1,7 +1,0 @@
-"""Tools for photo collections.
-
-This package provides tools for managing photo collections.
-"""
-
-__version__ = "0.9.3"
-__author__ = "Rolf Krahl <rolf@rotkraut.de>"

--- a/python-photo.spec
+++ b/python-photo.spec
@@ -1,27 +1,26 @@
-%define pkgname		 photo
+%bcond_with tests
+%global distname photo
 
-Name:		python3-%{pkgname}
-Version:	0.9.3
-Release:	1
-Summary:	Tools for managing photo collections
+Name:		python3-%{distname}
+Version:	$version
+Release:	0
+Summary:	$description
+Url:		$url
 License:	Apache-2.0
-Group:		Development/Languages/Python
-Url:		https://github.com/RKrahl/photo-tools
-Source:		%{pkgname}-%{version}.tar.gz
-BuildArch:	noarch
-BuildRequires:	python3-devel >= 3.6
+Group:		Productivity/Graphics/Viewers
+Source:		%{distname}-%{version}.tar.gz
+BuildRequires:	fdupes
 BuildRequires:	python3-PyYAML
+BuildRequires:	python3-devel >= 3.6
 BuildRequires:	python3-exif >= 0.8.3
+%if %{with tests}
+BuildRequires:	python3-distutils-pytest
 BuildRequires:	python3-pytest
-%if 0%{?sle_version} >= 150000 || 0%{?sle_version} == 120300
 BuildRequires:	python3-pytest-dependency
 %endif
-BuildRequires:	python3-distutils-pytest
 Requires:	python3-PyYAML
 Requires:	python3-exif >= 0.8.3
-%if 0%{?suse_version}
-BuildRequires:	fdupes
-%endif
+BuildArch:	noarch
 BuildRoot:	%{_tmppath}/%{name}-%{version}-build
 
 %description
@@ -31,7 +30,7 @@ maintaining tags in a collection of photos.
 
 %package qt
 Summary:	Tools for managing photo collections
-Requires:	python3-%{pkgname} = %{version}
+Requires:	python3-%{distname} = %{version}
 Requires:	python3-pyside
 Recommends:	python3-vignette >= 4.3.0
 
@@ -40,7 +39,7 @@ This package provides an image viewer for collection of photos.
 
 
 %prep
-%setup -q -n %{pkgname}-%{version}
+%setup -q -n %{distname}-%{version}
 
 
 %build
@@ -51,17 +50,13 @@ python3 setup.py build
 python3 setup.py install --optimize=1 --prefix=%{_prefix} --root=%{buildroot}
 %__mv %{buildroot}%{_bindir}/photoidx.py %{buildroot}%{_bindir}/photoidx
 %__mv %{buildroot}%{_bindir}/imageview.py %{buildroot}%{_bindir}/imageview
-%if 0%{?suse_version}
 %fdupes %{buildroot}
-%endif
 
 
+%if %{with tests}
 %check
 python3 setup.py test
-
-
-%clean
-rm -rf %{buildroot}
+%endif
 
 
 %files

--- a/python-photo.spec
+++ b/python-photo.spec
@@ -1,4 +1,4 @@
-%bcond_with tests
+%bcond_without tests
 %global distname photo
 
 Name:		python3-%{distname}

--- a/setup.py
+++ b/setup.py
@@ -1,40 +1,111 @@
-#! /usr/bin/python
+"""Tools for photo collections.
 
+This package provides tools for managing photo collections.
+"""
+
+import distutils.command.build_py
+import distutils.command.sdist
+import distutils.core
 from distutils.core import setup
+import distutils.log
+from glob import glob
+from pathlib import Path
+import string
 try:
     import distutils_pytest
 except ImportError:
     pass
-import photo
-import re
+try:
+    import setuptools_scm
+    version = setuptools_scm.get_version()
+    with open(".version", "wt") as f:
+        f.write(version)
+except (ImportError, LookupError):
+    try:
+        with open(".version", "rt") as f:
+            version = f.read()
+    except OSError:
+        distutils.log.warn("warning: cannot determine version number")
+        version = "UNKNOWN"
 
-DOCLINES         = photo.__doc__.split("\n")
-DESCRIPTION      = DOCLINES[0]
-LONG_DESCRIPTION = "\n".join(DOCLINES[2:])
-VERSION          = photo.__version__
-AUTHOR           = photo.__author__
-m = re.match(r"^(.*?)\s*<(.*)>$", AUTHOR)
-(AUTHOR_NAME, AUTHOR_EMAIL) = m.groups() if m else (AUTHOR, None)
+doclines = __doc__.strip().split("\n")
+
+
+class init_py(distutils.core.Command):
+
+    description = "generate the main __init__.py file"
+    user_options = []
+    init_template = '''"""%s"""
+
+__version__ = "%s"
+'''
+
+    def initialize_options(self):
+        self.package_dir = None
+
+    def finalize_options(self):
+        self.package_dir = {}
+        if self.distribution.package_dir:
+            for name, path in self.distribution.package_dir.items():
+                self.package_dir[name] = convert_path(path)
+
+    def run(self):
+        try:
+            pkgname = self.distribution.packages[0]
+        except IndexError:
+            distutils.log.warn("warning: no package defined")
+        else:
+            pkgdir = Path(self.package_dir.get(pkgname, pkgname))
+            ver = self.distribution.get_version()
+            if not pkgdir.is_dir():
+                pkgdir.mkdir()
+            with (pkgdir / "__init__.py").open("wt") as f:
+                print(self.init_template % (__doc__, ver), file=f)
+
+
+class sdist(distutils.command.sdist.sdist):
+    def run(self):
+        self.run_command('init_py')
+        super().run()
+        subst = {
+            "version": self.distribution.get_version(),
+            "url": self.distribution.get_url(),
+            "description": self.distribution.get_description(),
+            "long_description": self.distribution.get_long_description(),
+        }
+        for spec in glob("*.spec"):
+            with Path(spec).open('rt') as inf:
+                with Path(self.dist_dir, spec).open('wt') as outf:
+                    outf.write(string.Template(inf.read()).substitute(subst))
+
+
+class build_py(distutils.command.build_py.build_py):
+    def run(self):
+        self.run_command('init_py')
+        super().run()
 
 
 setup(
     name = "photo",
-    version = VERSION,
-    description = DESCRIPTION,
-    long_description = LONG_DESCRIPTION,
-    author = AUTHOR_NAME,
-    author_email = AUTHOR_EMAIL,
+    version = version,
+    description = doclines[0],
+    long_description = "\n".join(doclines[2:]),
+    author = "Rolf Krahl",
+    author_email = "rolf@rotkraut.de",
+    url = "https://github.com/RKrahl/photo-tools",
     license = "Apache-2.0",
     requires = ["PyYAML", "exif"],
     packages = ["photo", "photo.qt"],
     scripts = ["photoidx.py", "imageview.py"],
     classifiers = [
         "Development Status :: 5 - Production/Stable",
+        "Intended Audience :: End Users/Desktop",
         "License :: OSI Approved :: Apache Software License",
         "Operating System :: OS Independent",
         "Programming Language :: Python",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
-        ],
+    ],
+    cmdclass = {'build_py': build_py, 'sdist': sdist, 'init_py': init_py},
 )


### PR DESCRIPTION
Use `setuptools_scm` to manage the version number.  Generate `photo/__init__.py` automatically out of `setup.py`.  Close #47.