### PR TITLE
Add geo information in the output of the stats command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,19 @@ Changelog
 =========
 
 
+0.10.0 (not yet released)
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+New features
+------------
+
++ `#38`_, `#62`_: Add geo information to the output of the `stats`
+  subcommand in :ref:`photo-idx`.
+
+.. _#38: https://github.com/RKrahl/photoidx/issues/38
+.. _#62: https://github.com/RKrahl/photoidx/pull/62
+
+
 0.10.1 (2023-09-24)
 ~~~~~~~~~~~~~~~~~~~
 

--- a/photoidx/geo.py
+++ b/photoidx/geo.py
@@ -97,8 +97,13 @@ class GeoPosition(object):
             self.lon.ref(): float(abs(self.lon))
         }
 
-    def as_osmurl(self, zoom=16):
+    def as_osmurl(self, zoom=None, radius=None):
         """Return an URL to OpenStreetMap displaying this position."""
+        if not zoom:
+            if radius:
+                zoom = int(-1.35 * math.log(max(radius, 0.05)) + 14.5)
+            else:
+                zoom = 16
         template = "http://www.openstreetmap.org/?mlat=%f&mlon=%f&zoom=%d"
         return template % (self.lat, self.lon, zoom)
 

--- a/photoidx/geo.py
+++ b/photoidx/geo.py
@@ -3,7 +3,7 @@
 
 import re
 import math
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 
 
 _geopos_pattern = (r"^\s*(?P<lat>\d+(?:\.\d*))\s*(?P<latref>N|S),\s*"
@@ -71,6 +71,14 @@ class GeoPosition(object):
                 self.lon = lon(lonsign*float(m.group('lon')))
             else:
                 raise ValueError("invalid Geo position '%s'." % pos)
+        elif isinstance(pos, Sequence):
+            if len(pos) == 2:
+                self.lat = lat(pos[0])
+                self.lon = lon(pos[1])
+            else:
+                raise ValueError("invalid Geo position %s: "
+                                 "must have two elements."
+                                 % str(pos))
         else:
             raise TypeError("invalid type '%s'" % type(pos))
 

--- a/photoidx/stats.py
+++ b/photoidx/stats.py
@@ -54,8 +54,9 @@ class Stats(object):
             s += "Oldest: %s\n" % str(self.oldest)
             s += "Newest: %s\n" % str(self.newest)
         if self.gpsCenter:
+            osmurl = self.gpsCenter.as_osmurl(radius=self.gpsRadius)
             s += "GPS center: %s\n" % str(self.gpsCenter)
-            s += "            (%s)\n" % self.gpsCenter.as_osmurl(zoom=8)
+            s += "            (%s)\n" % osmurl
             s += "GPS radius: %.2f km\n" % self.gpsRadius
         if self.by_date:
             s += "By date:\n"


### PR DESCRIPTION
- Extend `class GeoPosition`:
  -  add a class method `centroid()` that returns the centroid of GeoPositions,
  - add a keyword argument `radius` to method `as_osmurl()`, the method will calculate an appropriate default `zoom` for the `url` so that this radius is approximately visible in the browser.
- Add "GPS center" and "GPS radius" to the output of the `stats` subcommand of the `photo-idx` script.

Close #38.