### PR TITLE
Minor refactor of test suite

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -15,10 +15,12 @@ Internal changes
 ----------------
 
 + `#66`_: Review build tool chain.
++ `#69`_: Refactor test suite.
 
 .. _#38: https://github.com/RKrahl/photoidx/issues/38
 .. _#62: https://github.com/RKrahl/photoidx/pull/62
 .. _#66: https://github.com/RKrahl/photoidx/pull/66
+.. _#69: https://github.com/RKrahl/photoidx/pull/69
 
 
 0.10.1 (2023-09-24)
@@ -52,6 +54,8 @@ New features
 
 Incompatible changes
 --------------------
+
++ Require Python 3.6 or newer.
 
 + `#52`_, `#53`_: Rename the package from ``photo`` to ``photoidx``.
 

--- a/README.rst
+++ b/README.rst
@@ -59,7 +59,7 @@ Optional library packages:
   to build out of the plain development source tree as cloned from
   GitHub, but not to build a release distribution.
 
-+ `pytest`_ >= 3.0.0
++ `pytest`_ >= 3.1.0
 
   Only needed to run the test suite.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,12 +16,12 @@ testdir = Path(__file__).parent
 def gettestdata(fname):
     fname = testdir / "data" / fname
     assert fname.is_file()
-    return str(fname)
+    return fname
 
 @pytest.fixture(scope="module")
 def tmpdir(request):
-    td = tempfile.mkdtemp(prefix="photoidx-test-")
-    yield Path(td)
+    td = Path(tempfile.mkdtemp(prefix="photoidx-test-"))
+    yield td
     shutil.rmtree(td)
 
 def callscript(scriptname, args, stdin=None, stdout=None, stderr=None):

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-minversion = 3.0.0
+minversion = 3.1.0

--- a/tests/test_02_create_index.py
+++ b/tests/test_02_create_index.py
@@ -18,13 +18,13 @@ refindex = gettestdata("index-create.yaml")
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
+        shutil.copy(fname, tmpdir)
     return tmpdir
 
 def test_create_curdir(imgdir, monkeypatch):
     """Create a new index in the current directory adding all images.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     with photoidx.index.Index(imgdir=".") as idx:
         idx.write()
     idxfile = ".index.yaml"
@@ -36,7 +36,7 @@ def test_create(imgdir):
     """
     with photoidx.index.Index(imgdir=imgdir) as idx:
         idx.write()
-    idxfile = str(imgdir / ".index.yaml")
+    idxfile = imgdir / ".index.yaml"
     assert filecmp.cmp(refindex, idxfile), "index file differs from reference"
 
 @pytest.mark.dependency(depends=["test_create"])
@@ -45,5 +45,5 @@ def test_read(imgdir):
     """
     with photoidx.index.Index(idxfile=imgdir) as idx:
         idx.write()
-    idxfile = str(imgdir / ".index.yaml")
+    idxfile = imgdir / ".index.yaml"
     assert filecmp.cmp(refindex, idxfile), "index file differs from reference"

--- a/tests/test_02_filter.py
+++ b/tests/test_02_filter.py
@@ -19,8 +19,8 @@ testimgfiles = [ gettestdata(i) for i in testimgs ]
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
-    shutil.copy(gettestdata("index-tagged.yaml"), str(tmpdir / ".index.yaml"))
+        shutil.copy(fname, tmpdir)
+    shutil.copy(gettestdata("index-tagged.yaml"), tmpdir / ".index.yaml")
     return tmpdir
 
 def test_by_date(imgdir):

--- a/tests/test_02_read_write.py
+++ b/tests/test_02_read_write.py
@@ -19,7 +19,7 @@ refindexu = gettestdata("index-unicode-tags.yaml")
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
+        shutil.copy(fname, tmpdir)
     return tmpdir
 
 def test_read_non_existent(imgdir):
@@ -32,7 +32,7 @@ def test_read_non_existent(imgdir):
 def test_read_write(imgdir):
     """Read the index file and write it out again.
     """
-    idxfile = str(imgdir / ".index.yaml")
+    idxfile = imgdir / ".index.yaml"
     shutil.copy(refindex, idxfile)
     with photoidx.index.Index(idxfile=imgdir) as idx:
         idx.write()
@@ -41,7 +41,7 @@ def test_read_write(imgdir):
 def test_read_write_unicode(imgdir):
     """Same test as above but with non-ASCII characters in the tags.
     """
-    idxfile = str(imgdir / ".index.yaml")
+    idxfile = imgdir / ".index.yaml"
     shutil.copy(refindexu, idxfile)
     with photoidx.index.Index(idxfile=imgdir) as idx:
         idx.write()

--- a/tests/test_03_photoidx.py
+++ b/tests/test_03_photoidx.py
@@ -21,7 +21,7 @@ refindex = gettestdata("index-create.yaml")
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
+        shutil.copy(fname, tmpdir)
     return tmpdir
 
 
@@ -35,9 +35,9 @@ def imgdir(tmpdir):
 def test_create(imgdir, monkeypatch):
     """Create the index.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     callscript("photo-idx.py", ["create"])
-    idxfile = str(imgdir / ".index.yaml")
+    idxfile = imgdir / ".index.yaml"
     assert filecmp.cmp(refindex, idxfile), "index file differs from reference"
 
 @pytest.mark.dependency(depends=["test_create"])
@@ -58,7 +58,7 @@ def test_ls_md5(imgdir, monkeypatch):
     md5sum = "/usr/bin/md5sum"
     if not Path(md5sum).is_file():
         pytest.skip("md5sum not found.")
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     fname = imgdir / "md5"
     with fname.open("wt") as f:
         callscript("photo-idx.py", ["ls", "--checksum=md5"], stdout=f)
@@ -99,7 +99,7 @@ def test_addtag_by_date(imgdir):
 def test_addtag_by_gpspos(imgdir, monkeypatch):
     """Select by GPS position.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     args = ["addtag", "--gpspos", "35.6883 N, 139.7544 E", 
             "--gpsradius", "20.0", "Tokyo"]
     callscript("photo-idx.py", args)
@@ -115,7 +115,7 @@ def test_addtag_by_gpspos(imgdir, monkeypatch):
 def test_addtag_by_files(imgdir, monkeypatch):
     """Select by file names.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     args = ["addtag", "Shinto_shrine", "dsc_4664.jpg", "dsc_4831.jpg"]
     callscript("photo-idx.py", args)
     fname = imgdir / "out"
@@ -133,7 +133,7 @@ def test_addtag_by_files(imgdir, monkeypatch):
 def test_rmtag_by_tag(imgdir, monkeypatch):
     """Remove a tag from images selected by tags.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     args = ["rmtag", "--tags", "Tokyo", "all"]
     callscript("photo-idx.py", args)
     args = ["rmtag", "--tags", "Hakone", "all"]
@@ -150,7 +150,7 @@ def test_rmtag_by_tag(imgdir, monkeypatch):
 def test_rmtag_all(imgdir, monkeypatch):
     """Remove a tag from all images.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     args = ["-d", str(imgdir), "rmtag", "all"]
     callscript("photo-idx.py", args)
     fname = imgdir / "out"
@@ -199,7 +199,7 @@ def test_ls_by_neg_tags(imgdir, monkeypatch):
     Prepending a tag by an exclamation mark selects the images having
     the tag not set.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     fname = imgdir / "out"
     with fname.open("wt") as f:
         args = ["ls", "--tags", "Tokyo,!Shinto_shrine"]
@@ -262,7 +262,7 @@ def test_lstags_all(imgdir):
 def test_lstags_by_tags(imgdir, monkeypatch):
     """List tags selected by tags.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     fname = imgdir / "out"
     with fname.open("wt") as f:
         args = ["lstags", "--tags", "Tokyo"]
@@ -275,7 +275,7 @@ def test_lstags_by_tags(imgdir, monkeypatch):
 def test_select_by_files(imgdir, monkeypatch):
     """Select by file names.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     args = ["select", "dsc_5126.jpg"]
     callscript("photo-idx.py", args)
     fname = imgdir / "out"
@@ -292,7 +292,7 @@ def test_select_by_files(imgdir, monkeypatch):
 def test_select_by_tag(imgdir, monkeypatch):
     """Select by tag.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     args = ["select", "--tags", "Shinto_shrine"]
     callscript("photo-idx.py", args)
     fname = imgdir / "out"
@@ -307,7 +307,7 @@ def test_select_by_tag(imgdir, monkeypatch):
 def test_deselect_by_files(imgdir, monkeypatch):
     """Deselect by file names.
     """
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     args = ["deselect", "dsc_4831.jpg"]
     callscript("photo-idx.py", args)
     fname = imgdir / "out"

--- a/tests/test_05_checksum.py
+++ b/tests/test_05_checksum.py
@@ -26,7 +26,7 @@ hashalg = {
 @pytest.mark.dependency()
 def test_create_checksum(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
+        shutil.copy(fname, tmpdir)
     with photoidx.index.Index(imgdir=tmpdir, hashalg=hashalg.keys()) as idx:
         idx.write()
 
@@ -40,7 +40,7 @@ def test_check_checksum(tmpdir, monkeypatch, alg):
     with photoidx.index.Index(idxfile=tmpdir) as idx, fname.open("wt") as f:
         for i in idx:
             print("%s  %s" % (i.checksum[alg], i.filename), file=f)
-    monkeypatch.chdir(str(tmpdir))
+    monkeypatch.chdir(tmpdir)
     with fname.open("rt") as f:
         cmd = [checkprog, "-c"]
         print(">", *cmd)

--- a/tests/test_05_createupdate.py
+++ b/tests/test_05_createupdate.py
@@ -17,12 +17,12 @@ refindex = gettestdata("index-create.yaml")
 
 def test_createupdate(tmpdir):
     for fname in testimgfiles[:3]:
-        shutil.copy(fname, str(tmpdir))
+        shutil.copy(fname, tmpdir)
     with photoidx.index.Index(imgdir=tmpdir) as idx:
         idx.write()
     for fname in testimgfiles[3:]:
-        shutil.copy(fname, str(tmpdir))
+        shutil.copy(fname, tmpdir)
     with photoidx.index.Index(idxfile=tmpdir, imgdir=tmpdir) as idx:
         idx.write()
-    idxfile = str(tmpdir / ".index.yaml")
+    idxfile = tmpdir / ".index.yaml"
     assert filecmp.cmp(refindex, idxfile), "index file differs from reference"

--- a/tests/test_05_legacy_md5.py
+++ b/tests/test_05_legacy_md5.py
@@ -23,8 +23,8 @@ refindex = gettestdata("index-create.yaml")
 
 def test_legacyconvert(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
-    idxfile = str(tmpdir / ".index.yaml")
+        shutil.copy(fname, tmpdir)
+    idxfile = tmpdir / ".index.yaml"
     shutil.copy(legacyindex, idxfile)
     # reading and writing the index transparantly converts it.
     with photoidx.index.Index(idxfile=tmpdir) as idx:

--- a/tests/test_05_missing_exif.py
+++ b/tests/test_05_missing_exif.py
@@ -20,7 +20,7 @@ testimgfiles = [ gettestdata(i) for i in testimgs ]
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
+        shutil.copy(fname, tmpdir)
     return tmpdir
 
 def test_create(imgdir):

--- a/tests/test_05_name.py
+++ b/tests/test_05_name.py
@@ -11,7 +11,7 @@ refindex = gettestdata("index-name.yaml")
 
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
-    shutil.copy(refindex, str(tmpdir / ".index.yaml"))
+    shutil.copy(refindex, tmpdir / ".index.yaml")
     return tmpdir
 
 def test_readwrite(imgdir):
@@ -22,5 +22,5 @@ def test_readwrite(imgdir):
         assert idx[1].name is None
         assert idx[3].name == "geisha.jpg"
         idx.write()
-    idxfile = str(imgdir / ".index.yaml")
+    idxfile = imgdir / ".index.yaml"
     assert filecmp.cmp(refindex, idxfile), "index file differs from reference"

--- a/tests/test_05_reserved_tag.py
+++ b/tests/test_05_reserved_tag.py
@@ -21,8 +21,8 @@ refindex = gettestdata("index-tagged.yaml")
 
 def test_reserved_tags_convert(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
-    idxfile = str(tmpdir / ".index.yaml")
+        shutil.copy(fname, tmpdir)
+    idxfile = tmpdir / ".index.yaml"
     shutil.copy(invindex, idxfile)
     # reading and writing the index transparantly filters out tags
     # using the reserved prefix.

--- a/tests/test_05_stats.py
+++ b/tests/test_05_stats.py
@@ -20,8 +20,8 @@ testimgfiles = [ gettestdata(i) for i in testimgs ]
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
-    shutil.copy(gettestdata("index-tagged.yaml"), str(tmpdir / ".index.yaml"))
+        shutil.copy(fname, tmpdir)
+    shutil.copy(gettestdata("index-tagged.yaml"), tmpdir / ".index.yaml")
     return tmpdir
 
 

--- a/tests/test_05_subdirs.py
+++ b/tests/test_05_subdirs.py
@@ -33,7 +33,7 @@ def imgdir(tmpdir):
         d = tmpdir / k
         d.mkdir()
         for f in testimgs[k]:
-            shutil.copy(gettestdata(f), str(d / f))
+            shutil.copy(gettestdata(f), d / f)
     return tmpdir
 
 @pytest.mark.dependency()
@@ -44,7 +44,7 @@ def test_create(imgdir):
         for k in ("Japan", "Quebec"):
             idx.extend_dir(imgdir / k)
         idx.write()
-    idxfile = str(imgdir / ".index.yaml")
+    idxfile = imgdir / ".index.yaml"
     assert filecmp.cmp(refindex, idxfile), "index file differs from reference"
 
 @pytest.mark.dependency(depends=["test_create"])
@@ -61,7 +61,7 @@ def test_checksum(imgdir, monkeypatch):
         with fname.open("wt") as f:
             for i in idx:
                 print("%s  %s" % (i.checksum[hashalg], i.filename), file=f)
-    monkeypatch.chdir(str(imgdir))
+    monkeypatch.chdir(imgdir)
     with fname.open("rt") as f:
         cmd = [checkprog, "-c"]
         print(">", *cmd)

--- a/tests/test_05_tagorder.py
+++ b/tests/test_05_tagorder.py
@@ -24,7 +24,7 @@ testimgfiles = [ gettestdata(i) for i in testimgs ]
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
+        shutil.copy(fname, tmpdir)
     return tmpdir
 
 # Each test ends up adding the same set of tags to each image.  But
@@ -48,8 +48,8 @@ tags = {
 
 @pytest.mark.dependency()
 def test_tag_ref(imgdir):
-    idxfname = str(imgdir / ".index.yaml")
-    reffname = str(imgdir / "index-ref.yaml")
+    idxfname = imgdir / ".index.yaml"
+    reffname = imgdir / "index-ref.yaml"
     shutil.copy(gettestdata("index-create.yaml"), idxfname)
     with photoidx.index.Index(idxfile=imgdir) as idx:
         taglist = [ "Japan", "Tokyo", "Hakone", "Kyoto", 
@@ -65,8 +65,8 @@ def test_tag_ref(imgdir):
 def test_tag_shuffle(imgdir):
     """Same as test_tag_ref(), only the order of setting the tags differ.
     """
-    idxfname = str(imgdir / ".index.yaml")
-    reffname = str(imgdir / "index-ref.yaml")
+    idxfname = imgdir / ".index.yaml"
+    reffname = imgdir / "index-ref.yaml"
     shutil.copy(gettestdata("index-create.yaml"), idxfname)
     with photoidx.index.Index(idxfile=imgdir) as idx:
         taglist = [ "Ginza", "Hakone", "Japan", "Geisha", 
@@ -82,8 +82,8 @@ def test_tag_shuffle(imgdir):
 def test_tag_remove(imgdir):
     """First set all tags on all images, then remove the wrong ones.
     """
-    idxfname = str(imgdir / ".index.yaml")
-    reffname = str(imgdir / "index-ref.yaml")
+    idxfname = imgdir / ".index.yaml"
+    reffname = imgdir / "index-ref.yaml"
     shutil.copy(gettestdata("index-create.yaml"), idxfname)
     with photoidx.index.Index(idxfile=imgdir) as idx:
         taglist = [ "Tokyo", "Shinto_shrine", "Ginza", "Geisha", 
@@ -102,8 +102,8 @@ def test_tag_remove(imgdir):
 def test_tag_extra(imgdir):
     """Add a spurious extra tag first and remove it later.
     """
-    idxfname = str(imgdir / ".index.yaml")
-    reffname = str(imgdir / "index-ref.yaml")
+    idxfname = imgdir / ".index.yaml"
+    reffname = imgdir / "index-ref.yaml"
     shutil.copy(gettestdata("index-create.yaml"), idxfname)
     with photoidx.index.Index(idxfile=imgdir) as idx:
         taglist = [ "Japan", "Tokyo", "Hakone", "Kyoto", 

--- a/tests/test_05_unicode_tags.py
+++ b/tests/test_05_unicode_tags.py
@@ -30,8 +30,8 @@ tags = {
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
-    shutil.copy(baseindex, str(tmpdir / ".index.yaml"))
+        shutil.copy(fname, tmpdir)
+    shutil.copy(baseindex, tmpdir / ".index.yaml")
     return tmpdir
 
 def test_tag_unicode(imgdir):
@@ -40,5 +40,5 @@ def test_tag_unicode(imgdir):
             for t in tags[str(item.filename)]:
                 item.tags.add(t)
         idx.write()
-    idxfile = str(imgdir / ".index.yaml")
+    idxfile = imgdir / ".index.yaml"
     assert filecmp.cmp(refindex, idxfile), "index file differs from reference"

--- a/tests/test_06_filelock.py
+++ b/tests/test_06_filelock.py
@@ -29,8 +29,8 @@ tags = {
 @pytest.fixture(scope="module")
 def imgdir(tmpdir):
     for fname in testimgfiles:
-        shutil.copy(fname, str(tmpdir))
-    shutil.copy(refindex, str(tmpdir / ".index.yaml"))
+        shutil.copy(fname, tmpdir)
+    shutil.copy(refindex, tmpdir / ".index.yaml")
     return tmpdir
 
 # --------------------------------------------------------------------
@@ -123,5 +123,5 @@ def test_concurrent_read_write(imgdir):
         p.join()
     # Finally, verify that the index is still unchanged, so the
     # writing did not succeed.
-    idxfile = str(imgdir / ".index.yaml")
+    idxfile = imgdir / ".index.yaml"
     assert filecmp.cmp(refindex, idxfile), "index file differs from reference"


### PR DESCRIPTION
- Remove many conversions of `Path` objects to `str` in the tests.  (This requires Python 3.6, but we require this version since 0.10 anyway.)
- Fix requirements: the test suite actually requires at least pytest 3.1.0.